### PR TITLE
file download tweaks for multiple paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # s3fs (development version)
 
-* Fix for `s3_file_download` to allow multiple file paths passed to `new_path` (#34)
+* Fix for `s3_file_download` to allow multiple file paths passed to `new_path` (#34), thanks to @sckott for contribution.
+* Fix for `s3_file_info`, convert `logical(0)` to `NA` to correctly build `data.frame` output.
 
 # s3fs 0.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# s3fs (development version)
+
+* Fix for `s3_file_download` to allow multiple file paths passed to `new_path` (#34)
+
 # s3fs 0.1.4
 
 * Fix ensure path is returned for already existing directories (#28)

--- a/R/s3filesystem_class.R
+++ b/R/s3filesystem_class.R
@@ -524,12 +524,12 @@ S3FileSystem = R6Class("S3FileSystem",
           )
           resp$size = resp$ContentLength
           resp$ContentLength = NULL
-          resp$type = ifelse(endsWith(s3_parts[[i]]$Key, "/"), "directory", "file")
-          suppressWarnings(as.data.table(resp))
+          resp$type = if (endsWith(s3_parts[[i]]$Key, "/")) "directory" else "file"
+          resp[lengths(resp) == 0] = lapply(resp[lengths(resp) == 0], as.na)
+          as.data.table(resp)
         },
         future.seed = length(s3_parts)
       )
-
       dt = rbindlist(resp)
       names(dt) = camel_to_snake(names(dt))
       setnames(dt, "e_tag", "etag")
@@ -2153,9 +2153,9 @@ S3FileSystem = R6Class("S3FileSystem",
                 else ""
               ),
               size = c$Size,
-              type = ifelse(endsWith(c$Key, "/"), "directory", "file"),
-              owner = ifelse(
-                identical(c$Owner$DisplayName, character(0)), "", c$Owner$DisplayName
+              type = if (endsWith(c$Key, "/")) "directory" else "file",
+              owner = (
+                if (identical(c$Owner$DisplayName, character(0))) NA_character_ else c$Owner$DisplayName
               ),
               etag = c$ETag,
               last_modified = c$LastModified
@@ -2181,7 +2181,7 @@ S3FileSystem = R6Class("S3FileSystem",
             type = "directory",
             owner = "",
             etag = "",
-            last_modified = as.POSIXct(NA)
+            last_modified = na_posixct()
           )
         })
         s3_ls = rbind(rbindlist(s3_files),rbindlist(s3_dir))

--- a/R/s3filesystem_class.R
+++ b/R/s3filesystem_class.R
@@ -396,7 +396,7 @@ S3FileSystem = R6Class("S3FileSystem",
       dir.create(unique(dirname(new_path)), showWarnings = F, recursive = T)
       new_path = path_abs(new_path)
 
-      if (length(new_path) == 1 & fs::is_dir(new_path)) {
+      if (length(new_path) == 1 && all(fs::is_dir(new_path))) {
         new_path = rep(new_path, length(path))
         new_path = paste(trimws(new_path, "right", "/"), basename(path), sep = "/")
         dir.create(unique(dirname(new_path)), showWarnings = F, recursive = T)

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,3 +110,21 @@ now_utc = function(){
   attr(now, "tzone") <- "UTC"
   now
 }
+
+na_posixct <- function() {
+  out = NA_integer_
+  class(out) <-  c("POSIXct", "POSIXt")
+  return(out)
+}
+
+as.na <- function(x) {
+  switch(
+    class(x)[[1]],
+    "logical" = NA,
+    "character" = NA_character_,
+    "integer" = NA_integer_,
+    "POSIXct" = na_posixct(),
+    x
+  )
+}
+


### PR DESCRIPTION
two changes here:

1. change single `&` to double `&&` as I assume you intended to end up with a single boolean in the if block?
2. and change `fs::is_dir(new_path)` to `all(fs::is_dir(new_path))` so that i can pass in multiple paths to `s3_file_download`. perhaps this is the wrong behavior? I don't know the code here well enough to know

With current version of the package

```r
library(s3fs)
library(dplyr)
s3paths <- s3_dir_info("s64-test-22") %>% pull(uri) # length is 4
dfiles <- replicate(n = 4, tempfile())
s3_file_download(
    path = s3paths, 
    new_path = dfiles
)
#> Error in if (length(new_path) == 1 & fs::is_dir(new_path)) {: the condition has length > 1
```

With this change

```r
library(s3fs)
library(dplyr)
s3paths <- s3_dir_info("s64-test-22") %>% pull(uri) # length is 4
dfiles <- replicate(n = 4, tempfile())
s3_file_download(
    path = s3paths, 
    new_path = dfiles
)
#> [1] "/var/folders/qt/fzq1m_bj2yb_7b2jz57s9q7c0000gp/T//Rtmpagnkcx/filecfc62b59ced4"
#> [2] "/var/folders/qt/fzq1m_bj2yb_7b2jz57s9q7c0000gp/T//Rtmpagnkcx/filecfc61519d688"
#> [3] "/var/folders/qt/fzq1m_bj2yb_7b2jz57s9q7c0000gp/T//Rtmpagnkcx/filecfc65353858a"
#> [4] "/var/folders/qt/fzq1m_bj2yb_7b2jz57s9q7c0000gp/T//Rtmpagnkcx/filecfc6106451c3"
```