### PR TITLE
fix: suppress warning in `S3FileSystem`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Suppress warning in `S3FileSystem` triggered from `s3_file_delete()` (#42, @salim-b)
+
 # s3fs 0.1.5
 
 * Fix for `s3_file_download` to allow multiple file paths passed to `new_path` (#34), thanks to @sckott for contribution.

--- a/R/s3filesystem_class.R
+++ b/R/s3filesystem_class.R
@@ -1045,14 +1045,16 @@ S3FileSystem = R6Class("S3FileSystem",
             kwargs$VersionIdMarker = resp$VersionIdMarker
             kwargs$KeyMarker = resp$KeyMarker
 
-            df = rbindlist(
-              lapply(resp$Versions, function(v)
-                list(
-                  size = v$Size,
-                  version_id =v$VersionId,
-                  owner = v$Owner$DisplayName,
-                  etag = v$ETag,
-                  last_modified = v$LastModified
+            df = suppressWarnings(
+              rbindlist(
+                lapply(resp$Versions, function(v)
+                  list(
+                    size = v$Size,
+                    version_id =v$VersionId,
+                    owner = v$Owner$DisplayName,
+                    etag = v$ETag,
+                    last_modified = v$LastModified
+                  )
                 )
               )
             )


### PR DESCRIPTION
Fixes https://github.com/DyfanJones/s3fs/issues/42.

I 'm not familiar with s3fs's internals, so I don't know what unintended side effects this change could cause (i.e. wether it would also suppress important/legitimate warnings).